### PR TITLE
Fix/elimnar templates tp

### DIFF
--- a/PlanSCM.md
+++ b/PlanSCM.md
@@ -30,7 +30,6 @@
 			/Correcciones
 			/Entregas
 			/Enunciados
-			/Templates
 ```
 Donde N es el número de TP, Parcial o Unidad.
 


### PR DESCRIPTION
En la estructura de carpetas, se borraron los templates de la parte de TPs

Debido a que no se necesitan y es innecesaria la carpeta

